### PR TITLE
Removes bom and tool-list

### DIFF
--- a/okh-schema/okh-helpful.yaml
+++ b/okh-schema/okh-helpful.yaml
@@ -75,9 +75,6 @@ archive-download: include('url-type', required=False)                 # Absolute
 design-files: list(include('list-item'), required=False)
 schematics: list(include('list-item'), required=False)
 
-bom: include('url-type', required=False)                              # recommended | absolute or relative path | Direct the maker to the Bill of Materials
-tool-list: include('url-type', required=False)                        # recommended | absolute or relative path | Direct the maker to a list of tools required to make the thing
-
 # # Note, these have been added to the original IOP schema definition.
 bom-atoms: list(atom-type, required=False)
 tool-list-atoms: list(atom-type, required=False)


### PR DESCRIPTION
These were kept for backwards compatibility with the IOP OKH schema, but since the Helpful Schema effectively _extends_ that schema, the fields are redundant. 

tool-list: is a plaintext list of tools

`tool-list: hammer, screwdriver`

However, this data is already contained within the `description` field of Helpful's extension, `tool-list-atoms`.

I proposed that in order to preserve backwards compatibility, Helpful's tooling should add an export to IOP specification which would extract the `description` field from the `tool-list-atoms`, and flatten that into the plaintext list that conforms to IOP spec. This is a simple operation.