### PR TITLE
Create FabLab-self-descriptions.md

### DIFF
--- a/okw-schema/FabLab-self-descriptions.md
+++ b/okw-schema/FabLab-self-descriptions.md
@@ -1,0 +1,3 @@
+[Vancouver Hack Space](https://vanhack.ca/doku.php?id=tool)
+[CBA at MIT](http://cba.mit.edu/tools/index.html)
+Add other tool lists from FabLabs here...


### PR DESCRIPTION
List of links to lists of tools and machines from actual fablabs, which should serve as the basis of the OKW Schema Spec